### PR TITLE
Enable clear_cache to be called

### DIFF
--- a/omeka_s_tools/api.py
+++ b/omeka_s_tools/api.py
@@ -28,7 +28,7 @@ class OmekaAPIClient(object):
         self.s.mount('http://', HTTPAdapter(max_retries=retries))
         self.s.mount('https://', HTTPAdapter(max_retries=retries))
 
-    def clear_cache():
+    def clear_cache(self):
         self.s.cache.clear()
 
     def process_response(self, response):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
-from pkg_resources import parse_version
+#from pkg_resources import parse_version
 from configparser import ConfigParser
 import setuptools,re,sys
-assert parse_version(setuptools.__version__)>=parse_version('36.2')
+#assert parse_version(setuptools.__version__)>=parse_version('36.2')
 
 # note: all settings are in settings.ini; edit there, not here
 config = ConfigParser(delimiters=['='])


### PR DESCRIPTION
I was using omeka_s_tools to create a bunch of linked resources. For example, I might need to create an object and link it to a person. As the person might already exist, I was searching for the person, and if not found, creating it. If a later object linked to the same person, the newly-created person was not found because the search API call was cached. So I wanted to use clear_cache after creating a person to avoid this problem. Unfortunately the clear_cache routine had a bug and cannot be called in its current form. This is a simple fix to allow clear_cache() to be used, but the use of the cache could still trip people up if they are doing a mixture of creating and searching.